### PR TITLE
More reliable test dump

### DIFF
--- a/lib/xcknife.rb
+++ b/lib/xcknife.rb
@@ -6,5 +6,5 @@ require 'xcknife/test_dumper'
 require 'xcknife/exceptions'
 
 module XCKnife
-  VERSION = '0.6.0'
+  VERSION = '0.6.1'
 end


### PR DESCRIPTION
Waiting for test listing to finish on one bundle before going to the next. This avoids an error that happens when the same app is used for multiple test bundles, as there is a race condition where one test will override a previous one.