### PR TITLE
fixing test dumper debug logic

### DIFF
--- a/lib/xcknife.rb
+++ b/lib/xcknife.rb
@@ -7,5 +7,5 @@ require 'xcknife/exceptions'
 require 'xcknife/xcscheme_analyzer'
 
 module XCKnife
-  VERSION = '0.6.5'
+  VERSION = '0.6.6'
 end

--- a/lib/xcknife/test_dumper.rb
+++ b/lib/xcknife/test_dumper.rb
@@ -279,7 +279,7 @@ module XCKnife
     end
 
     def redirect_output
-      return '' unless @debug
+      return '' if @debug
       ' 2> /dev/null'
     end
 


### PR DESCRIPTION
Output was being redirected to dev null when the debug flag was set, which is the opposite of what we want.