### PR TITLE
Correct incorrect parameter setting when passed via command line option

### DIFF
--- a/lib/xcknife.rb
+++ b/lib/xcknife.rb
@@ -7,5 +7,5 @@ require 'xcknife/exceptions'
 require 'xcknife/xcscheme_analyzer'
 
 module XCKnife
-  VERSION = '0.11.0'
+  VERSION = '0.11.1'
 end

--- a/lib/xcknife/test_dumper.rb
+++ b/lib/xcknife/test_dumper.rb
@@ -25,12 +25,12 @@ module XCKnife
       @parser = build_parser
       @naive_dump_bundle_names = []
       @skip_dump_bundle_names = []
+      @simctl_timeout = 0
       parse_arguments(args)
       @device_id ||= "booted"
       @logger = logger
       @logger.level = @debug ? Logger::DEBUG : Logger::FATAL
       @parser = nil
-      @simctl_timeout = 0
     end
 
     def run


### PR DESCRIPTION
This PR moves the default setting for simctl_timeout to _before_ parameters are set via command line.