### PR TITLE
Parallelizes naive test dumping from nm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ TestDumper/TestDumper.dylib
 *.tmp
 .bin/
 .bundle/
+
 .vscode/launch.json

--- a/.vscode/configure.sh
+++ b/.vscode/configure.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+CWD=$(pwd)
+
+if [[ "$CWD" == *".vscode"* ]] ; then
+  cd ..
+fi
+
+RSPEC_PATH="$(command -v rspec)"
+BUNDLE_PATH="$(command -v bundle | sed 's/bin/wrappers/')"
+RDEBUG_PATH=$(cd ./ || exit 1; bundle show ruby-debug-ide)
+
+if [ -z "$RSPEC_PATH" ] || [ -z "$BUNDLE_PATH" ] || [ -z "$RDEBUG_PATH" ]; then
+  echo "error: Missing required gem, please run 'bundle install'"
+  exit 1
+fi
+
+echo "Using configuration paths:"
+echo "$RSPEC_PATH"
+echo "$BUNDLE_PATH"
+echo "$RDEBUG_PATH"
+
+cat < "./.vscode/vscode_ruby.json.template" | sed "s|RSPEC_PATH|$RSPEC_PATH|g" | sed "s|BUNDLE_PATH|$BUNDLE_PATH|g" | sed "s|RDEBUG_PATH|$RDEBUG_PATH|g" > ./.vscode/launch.json

--- a/.vscode/vscode_ruby.json.template
+++ b/.vscode/vscode_ruby.json.template
@@ -1,0 +1,44 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run RSpec - all",
+            "type": "Ruby",
+            "request": "launch",
+            "cwd": "${workspaceRoot}",
+            "useBundler": true,
+            "pathToBundler": "BUNDLE_PATH",
+            "program": "RSPEC_PATH",
+            "args": [
+                "--pattern",
+                "${workspaceRoot}/spec/**/*_spec.rb"
+            ]
+        },
+        {
+            "name": "Debug RSpec - open spec file",
+            "type": "Ruby",
+            "request": "launch",
+            "cwd": "${workspaceRoot}",
+            "useBundler": true,
+            "pathToBundler": "BUNDLE_PATH",
+            "pathToRDebugIDE": "RDEBUG_PATH",
+            "debuggerPort": "1235",
+            "program": "RSPEC_PATH",
+            "args": [
+                "${file}"
+            ]
+        },
+        {
+          "name": "Debug RSpec - open spec file & current line",
+          "type": "Ruby",
+          "request": "launch",
+          "cwd": "${workspaceRoot}",
+          "useBundler": true,
+          "pathToBundler": "BUNDLE_PATH",
+          "pathToRDebugIDE": "RDEBUG_PATH",
+          "debuggerPort": "1235",
+          "program": "RSPEC_PATH",
+          "args": ["${file}:${lineNumber}"]
+        }
+    ]
+}

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ group :development, :test do
 
   group :debug_vscode do
     gem 'debase'
-    gem 'ruby-debug-ide'
+    gem 'ruby-debug-ide', '~> 0.7.2'
   end
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,7 +35,7 @@ DEPENDENCIES
   debase
   rake (~> 13.0.1)
   rspec (~> 3.9.0)
-  ruby-debug-ide
+  ruby-debug-ide (~> 0.7.2)
   xcknife!
 
 BUNDLED WITH

--- a/lib/xcknife/test_dumper.rb
+++ b/lib/xcknife/test_dumper.rb
@@ -8,6 +8,7 @@ require 'logger'
 require 'shellwords'
 require 'open3'
 require 'xcknife/exceptions'
+require 'etc'
 
 module XCKnife
   class TestDumper
@@ -27,7 +28,7 @@ module XCKnife
       @skip_dump_bundle_names = []
       @simctl_timeout = 0
       parse_arguments(args)
-      @device_id ||= "booted"
+      @device_id ||= 'booted'
       @logger = logger
       @logger.level = @debug ? Logger::DEBUG : Logger::FATAL
       @parser = nil
@@ -38,9 +39,9 @@ module XCKnife
                                     naive_dump_bundle_names: @naive_dump_bundle_names, skip_dump_bundle_names: @skip_dump_bundle_names, simctl_timeout: @simctl_timeout)
       extra_environment_variables = parse_scheme_file
       logger.info { "Environment variables from xcscheme: #{extra_environment_variables.pretty_inspect}" }
-      output_fd = File.open(@output_file, "w")
+      output_fd = File.open(@output_file, 'w')
       if @temporary_output_folder.nil?
-        Dir.mktmpdir("xctestdumper_") do |outfolder|
+        Dir.mktmpdir('xctestdumper_') do |outfolder|
           list_tests(extra_environment_variables, helper, outfolder, output_fd)
         end
       else
@@ -48,60 +49,57 @@ module XCKnife
           raise TestDumpError, "Error no such directory: #{@temporary_output_folder}"
         end
 
-        if Dir.entries(@temporary_output_folder).any? { |f| File.file?(File.join(@temporary_output_folder,f)) }
+        if Dir.entries(@temporary_output_folder).any? { |f| File.file?(File.join(@temporary_output_folder, f)) }
           puts "Warning: #{@temporary_output_folder} is not empty! Files can be overwritten."
         end
         list_tests(extra_environment_variables, helper, File.absolute_path(@temporary_output_folder), output_fd)
       end
       output_fd.close
-      puts "Done listing test methods"
+      puts 'Done listing test methods'
     end
 
     private
+
     def list_tests(extra_environment_variables, helper, outfolder, output_fd)
       helper.call(@derived_data_folder, outfolder, extra_environment_variables).each do |test_specification|
         concat_to_file(test_specification, output_fd)
       end
     end
 
-
     def parse_scheme_file
       return {} unless @xcscheme_file
-      unless File.exists?(@xcscheme_file)
-        raise ArgumentError, "Error: no such xcscheme file: #{@xcscheme_file}"
-      end
+      raise ArgumentError, "Error: no such xcscheme file: #{@xcscheme_file}" unless File.exist?(@xcscheme_file)
+
       XCKnife::XcschemeAnalyzer.extract_environment_variables(IO.read(@xcscheme_file))
     end
 
     def parse_arguments(args)
       positional_arguments = parse_options(args)
       if positional_arguments.size < required_arguments.size
-        warn_and_exit("You must specify *all* required arguments: #{required_arguments.join(", ")}")
+        warn_and_exit("You must specify *all* required arguments: #{required_arguments.join(', ')}")
       end
       @derived_data_folder, @output_file, @device_id = positional_arguments
     end
 
     def parse_options(args)
-      begin
-        return @parser.parse(args)
-      rescue OptionParser::ParseError => error
-        warn_and_exit(error)
-      end
+      @parser.parse(args)
+    rescue OptionParser::ParseError => e
+      warn_and_exit(e)
     end
 
     def build_parser
       OptionParser.new do |opts|
         opts.banner += " #{arguments_banner}"
-        opts.on("-d", "--debug", "Debug mode enabled") { |v| @debug = v }
-        opts.on("-r", "--retry-count COUNT", "Max retry count for simulator output", Integer) { |v| @max_retry_count = v }
-        opts.on("-x", '--simctl-timeout SECONDS', "Max allowed time in seconds for simctl commands", Integer) { |v| @simctl_timeout = v }
-        opts.on("-t", "--temporary-output OUTPUT_FOLDER", "Sets temporary Output folder") { |v| @temporary_output_folder = v }
-        opts.on("-s", "--scheme XCSCHEME_FILE", "Reads environments variables from the xcscheme file") { |v| @xcscheme_file = v }
-        opts.on("-l", "--dylib_logfile DYLIB_LOG_FILE", "Path for dylib log file") { |v| @dylib_logfile_path = v }
+        opts.on('-d', '--debug', 'Debug mode enabled') { |v| @debug = v }
+        opts.on('-r', '--retry-count COUNT', 'Max retry count for simulator output', Integer) { |v| @max_retry_count = v }
+        opts.on('-x', '--simctl-timeout SECONDS', 'Max allowed time in seconds for simctl commands', Integer) { |v| @simctl_timeout = v }
+        opts.on('-t', '--temporary-output OUTPUT_FOLDER', 'Sets temporary Output folder') { |v| @temporary_output_folder = v }
+        opts.on('-s', '--scheme XCSCHEME_FILE', 'Reads environments variables from the xcscheme file') { |v| @xcscheme_file = v }
+        opts.on('-l', '--dylib_logfile DYLIB_LOG_FILE', 'Path for dylib log file') { |v| @dylib_logfile_path = v }
         opts.on('--naive-dump TEST_BUNDLE_NAMES', 'List of test bundles to dump using static analysis', Array) { |v| @naive_dump_bundle_names = v }
         opts.on('--skip-dump TEST_BUNDLE_NAMES', 'List of test bundles to skip dumping', Array) { |v| @skip_dump_bundle_names = v }
 
-        opts.on_tail("-h", "--help", "Show this message") do
+        opts.on_tail('-h', '--help', 'Show this message') do
           puts opts
           exit
         end
@@ -118,7 +116,7 @@ module XCKnife
 
     def arguments_banner
       optional_args = optional_arguments.map { |a| "[#{a}]" }
-      (required_arguments + optional_args).join(" ")
+      (required_arguments + optional_args).join(' ')
     end
 
     def warn_and_exit(msg)
@@ -141,8 +139,9 @@ module XCKnife
 
     # Current limitation: this only supports class level skipping
     def should_test_event_be_ignored?(test_specification, event)
-      return false unless event["test"] == "1"
-      test_specification.skip_test_identifiers.include?(event["className"])
+      return false unless event['test'] == '1'
+
+      test_specification.skip_test_identifiers.include?(event['className'])
     end
   end
 
@@ -157,9 +156,9 @@ module XCKnife
       @simctl_path = `xcrun -f simctl`.strip
       @nm_path = `xcrun -f nm`.strip
       @swift_path = `xcrun -f swift`.strip
-      @platforms_path = File.join(@xcode_path, "Platforms")
-      @platform_path = File.join(@platforms_path, "iPhoneSimulator.platform")
-      @sdk_path = File.join(@platform_path, "Developer/SDKs/iPhoneSimulator.sdk")
+      @platforms_path = File.join(@xcode_path, 'Platforms')
+      @platform_path = File.join(@platforms_path, 'iPhoneSimulator.platform')
+      @sdk_path = File.join(@platform_path, 'Developer/SDKs/iPhoneSimulator.sdk')
       @testroot = nil
       @device_id = device_id
       @max_retry_count = max_retry_count
@@ -174,9 +173,8 @@ module XCKnife
     def call(derived_data_folder, list_folder, extra_environment_variables = {})
       @testroot = File.join(derived_data_folder, 'Build', 'Products')
       xctestrun_file = Dir[File.join(@testroot, '*.xctestrun')].first
-      if xctestrun_file.nil?
-        raise ArgumentError, "No xctestrun on #{@testroot}"
-      end
+      raise ArgumentError, "No xctestrun on #{@testroot}" if xctestrun_file.nil?
+
       xctestrun_as_json = `plutil -convert json -o - "#{xctestrun_file}"`
       FileUtils.mkdir_p(list_folder)
       list_tests(JSON.load(xctestrun_as_json), list_folder, extra_environment_variables)
@@ -186,52 +184,89 @@ module XCKnife
 
     attr_reader :testroot
 
-    def list_tests(xctestrun, list_folder, extra_environment_variables)
-      xctestrun.reject! { |test_bundle_name, _| test_bundle_name == '__xctestrun_metadata__' }
-      xctestrun.map do |test_bundle_name, test_bundle|
+    def test_groups(xctestrun)
+      xctestrun.group_by do |test_bundle_name, _test_bundle|
         if @skip_dump_bundle_names.include?(test_bundle_name)
-          logger.info { "Skipping dumping tests in `#{test_bundle_name}` -- writing out fake event"}
-          test_specification = list_single_test(list_folder, test_bundle, test_bundle_name)
+          'single'
         elsif @naive_dump_bundle_names.include?(test_bundle_name)
-          test_specification = list_tests_with_nm(list_folder, test_bundle, test_bundle_name)
+          'nm'
         else
-          test_specification = list_tests_with_simctl(list_folder, test_bundle, test_bundle_name, extra_environment_variables)
-          wait_test_dumper_completion(test_specification.json_stream_file)
+          'simctl'
         end
-
-        test_specification
       end
     end
 
-    def list_tests_with_simctl(list_folder, test_bundle, test_bundle_name, extra_environment_variables)
-      env_variables = test_bundle["EnvironmentVariables"]
-      testing_env_variables = test_bundle["TestingEnvironmentVariables"]
-      outpath = File.join(list_folder, test_bundle_name)
-      test_host = replace_vars(test_bundle["TestHostPath"])
-      test_bundle_path = replace_vars(test_bundle["TestBundlePath"], test_host)
-      test_dumper_path = File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'TestDumper', 'TestDumper.dylib'))
-      unless File.exist?(test_dumper_path)
-        raise TestDumpError, "Could not find TestDumper.dylib on #{test_dumper_path}"
+    # This executes naive test dumping in parallel by queueing up items onto a work queue to process
+    # with 1 new thread per processor. Results are placed onto a threadsafe spec queue to avoid writing
+    # to an object between threads, then popped off re-inserting them to our list of test results.
+    def list_tests(xctestrun, list_folder, extra_environment_variables)
+      xctestrun.reject! { |test_bundle_name, _| test_bundle_name == '__xctestrun_metadata__' }
+
+      test_runs_by_method = test_groups(xctestrun)
+      spec_queue = Queue.new
+      nm_bundle_queue = Queue.new
+      single_tests = test_runs_by_method['single'] || []
+      nm_tests = test_runs_by_method['nm'] || []
+      simctl_tests = test_runs_by_method['simctl'] || []
+
+      single_tests.each do |test_bundle_name, test_bundle|
+        logger.info { "Skipping dumping tests in `#{test_bundle_name}` -- writing out fake event" }
+        spec_queue << list_single_test(list_folder, test_bundle, test_bundle_name)
       end
 
-      is_logic_test = test_bundle["TestHostBundleIdentifier"].nil?
+      simctl_tests.each do |test_bundle_name, test_bundle|
+        test_spec = list_tests_with_simctl(list_folder, test_bundle, test_bundle_name, extra_environment_variables)
+        wait_test_dumper_completion(test_spec.json_stream_file)
+
+        spec_queue << test_spec
+      end
+
+      nm_tests.each { |item| nm_bundle_queue << item }
+
+      [Etc.nprocessors, nm_bundle_queue.size].min.times.map do
+        Thread.new do
+          Thread.current.abort_on_exception = true
+
+          until nm_bundle_queue.empty?
+            test_bundle_name, test_bundle = nm_bundle_queue.pop
+            spec_queue << list_tests_with_nm(list_folder, test_bundle, test_bundle_name)
+          end
+        end
+      end.each(&:join)
+
+      result = []
+      result << spec_queue.pop until spec_queue.empty?
+
+      result
+    end
+
+    def list_tests_with_simctl(list_folder, test_bundle, test_bundle_name, extra_environment_variables)
+      env_variables = test_bundle['EnvironmentVariables']
+      testing_env_variables = test_bundle['TestingEnvironmentVariables']
+      outpath = File.join(list_folder, test_bundle_name)
+      test_host = replace_vars(test_bundle['TestHostPath'])
+      test_bundle_path = replace_vars(test_bundle['TestBundlePath'], test_host)
+      test_dumper_path = File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'TestDumper', 'TestDumper.dylib'))
+      raise TestDumpError, "Could not find TestDumper.dylib on #{test_dumper_path}" unless File.exist?(test_dumper_path)
+
+      is_logic_test = test_bundle['TestHostBundleIdentifier'].nil?
       env = simctl_child_attrs(
-        "XCTEST_TYPE" => xctest_type(test_bundle),
-        "XCTEST_TARGET" => test_bundle_name,
-        "TestDumperOutputPath" => outpath,
-        "IDE_INJECTION_PATH" => testing_env_variables["DYLD_INSERT_LIBRARIES"],
-        "XCInjectBundleInto" => testing_env_variables["XCInjectBundleInto"],
-        "XCInjectBundle" => test_bundle_path,
-        "TestBundleLocation" => test_bundle_path,
-        "OS_ACTIVITY_MODE" => "disable",
-        "DYLD_PRINT_LIBRARIES" => "YES",
-        "DYLD_PRINT_ENV" => "YES",
-        "DYLD_ROOT_PATH" => @sdk_path,
-        "DYLD_LIBRARY_PATH" => env_variables["DYLD_LIBRARY_PATH"],
-        "DYLD_FRAMEWORK_PATH" => env_variables["DYLD_FRAMEWORK_PATH"],
-        "DYLD_FALLBACK_LIBRARY_PATH" => "#{@sdk_path}/usr/lib",
-        "DYLD_FALLBACK_FRAMEWORK_PATH" => "#{@platform_path}/Developer/Library/Frameworks",
-        "DYLD_INSERT_LIBRARIES" => test_dumper_path,
+        'XCTEST_TYPE' => xctest_type(test_bundle),
+        'XCTEST_TARGET' => test_bundle_name,
+        'TestDumperOutputPath' => outpath,
+        'IDE_INJECTION_PATH' => testing_env_variables['DYLD_INSERT_LIBRARIES'],
+        'XCInjectBundleInto' => testing_env_variables['XCInjectBundleInto'],
+        'XCInjectBundle' => test_bundle_path,
+        'TestBundleLocation' => test_bundle_path,
+        'OS_ACTIVITY_MODE' => 'disable',
+        'DYLD_PRINT_LIBRARIES' => 'YES',
+        'DYLD_PRINT_ENV' => 'YES',
+        'DYLD_ROOT_PATH' => @sdk_path,
+        'DYLD_LIBRARY_PATH' => env_variables['DYLD_LIBRARY_PATH'],
+        'DYLD_FRAMEWORK_PATH' => env_variables['DYLD_FRAMEWORK_PATH'],
+        'DYLD_FALLBACK_LIBRARY_PATH' => "#{@sdk_path}/usr/lib",
+        'DYLD_FALLBACK_FRAMEWORK_PATH' => "#{@platform_path}/Developer/Library/Frameworks",
+        'DYLD_INSERT_LIBRARIES' => test_dumper_path
       )
       env.merge!(simctl_child_attrs(extra_environment_variables))
       inject_vars(env, test_host)
@@ -241,11 +276,13 @@ module XCKnife
         run_logic_test(env, test_host, test_bundle_path)
       else
         install_app(test_host)
-        test_host_bundle_identifier = replace_vars(test_bundle["TestHostBundleIdentifier"], test_host)
+        test_host_bundle_identifier = replace_vars(test_bundle['TestHostBundleIdentifier'], test_host)
         run_apptest(env, test_host_bundle_identifier, test_bundle_path)
       end
-      return TestSpecification.new outpath, discover_tests_to_skip(test_bundle)
+      TestSpecification.new outpath, discover_tests_to_skip(test_bundle)
     end
+
+    # Improvement?: assume that everything in the historical info is correct, so dont simctl or nm, and just spit out exactly what it said the classes were
 
     def list_tests_with_nm(list_folder, test_bundle, test_bundle_name)
       output_methods(list_folder, test_bundle, test_bundle_name) do |test_bundle_path|
@@ -253,6 +290,7 @@ module XCKnife
         swift_demangled_nm(test_bundle_path) do |output|
           output.each_line do |line|
             next unless method = method_from_nm_line(line)
+
             methods << method
           end
         end
@@ -271,25 +309,25 @@ module XCKnife
       logger.info { "Writing out TestDumper file for #{test_bundle_name} to #{outpath}" }
       test_specification = TestSpecification.new outpath, discover_tests_to_skip(test_bundle)
 
-      test_bundle_path = replace_vars(test_bundle["TestBundlePath"], replace_vars(test_bundle["TestHostPath"]))
+      test_bundle_path = replace_vars(test_bundle['TestBundlePath'], replace_vars(test_bundle['TestHostPath']))
       methods = yield(test_bundle_path)
 
       test_type = xctest_type(test_bundle)
       File.open test_specification.json_stream_file, 'a' do |f|
-        f << JSON.dump(message: "Starting Test Dumper", event: "begin-test-suite", testType: test_type) << "\n"
+        f << JSON.dump(message: 'Starting Test Dumper', event: 'begin-test-suite', testType: test_type) << "\n"
         f << JSON.dump(event: 'begin-ocunit', bundleName: File.basename(test_bundle_path), targetName: test_bundle_name) << "\n"
         methods.map { |method| method[:class] }.uniq.each do |class_name|
-          f << JSON.dump(test: '1', className: class_name, event: "end-test", totalDuration: "0") << "\n"
+          f << JSON.dump(test: '1', className: class_name, event: 'end-test', totalDuration: '0') << "\n"
         end
-        f << JSON.dump(message: "Completed Test Dumper", event: "end-action", testType: test_type) << "\n"
+        f << JSON.dump(message: 'Completed Test Dumper', event: 'end-action', testType: test_type) << "\n"
       end
 
       test_specification
     end
 
     def discover_tests_to_skip(test_bundle)
-      identifier_for_test_method = "/"
-      skip_test_identifiers = test_bundle["SkipTestIdentifiers"] || []
+      identifier_for_test_method = '/'
+      skip_test_identifiers = test_bundle['SkipTestIdentifiers'] || []
       skip_test_identifiers.reject { |i| i.include?(identifier_for_test_method) }.to_set
     end
 
@@ -311,22 +349,22 @@ module XCKnife
         return []
       end
 
-      [path, "-k", "5", "#{@simctl_timeout}"]
+      [path, '-k', '5', @simctl_timeout.to_s]
     end
 
     def gtimeout_path
       `which gtimeout`.strip
     end
 
-    def replace_vars(str, testhost = "<UNKNOWN>")
-      str.gsub("__PLATFORMS__", @platforms_path).
-        gsub("__TESTHOST__", testhost).
-        gsub("__TESTROOT__", testroot)
+    def replace_vars(str, testhost = '<UNKNOWN>')
+      str.gsub('__PLATFORMS__', @platforms_path)
+         .gsub('__TESTHOST__', testhost)
+         .gsub('__TESTROOT__', testroot)
     end
 
     def inject_vars(env, test_host)
       env.each do |k, v|
-        env[k] = replace_vars(v || "", test_host)
+        env[k] = replace_vars(v || '', test_host)
       end
     end
 
@@ -339,45 +377,42 @@ module XCKnife
     def install_app(test_host_path)
       retries_count = 0
       max_retry_count = 3
-      until (retries_count > max_retry_count) or call_simctl(["install", @device_id, test_host_path])
+      until (retries_count > max_retry_count) || call_simctl(['install', @device_id, test_host_path])
         retries_count += 1
         call_simctl ['shutdown', @device_id]
         call_simctl ['boot', @device_id]
         sleep 1.0
       end
 
-      if retries_count > max_retry_count
-        raise TestDumpError, "Installing #{test_host_path} failed"
-      end
-
+      raise TestDumpError, "Installing #{test_host_path} failed" if retries_count > max_retry_count
     end
 
     def wait_test_dumper_completion(file)
       retries_count = 0
-      until has_test_dumper_terminated?(file)  do
+      until has_test_dumper_terminated?(file)
         retries_count += 1
-        if retries_count == @max_retry_count
-          raise TestDumpError, "Timeout error on: #{file}"
-        end
+        raise TestDumpError, "Timeout error on: #{file}" if retries_count == @max_retry_count
+
         sleep 0.1
       end
     end
 
     def has_test_dumper_terminated?(file)
-      return false unless File.exists?(file)
+      return false unless File.exist?(file)
+
       last_line = `tail -n 1 "#{file}"`
-      return last_line.include?("Completed Test Dumper")
+      last_line.include?('Completed Test Dumper')
     end
 
     def run_apptest(env, test_host_bundle_identifier, test_bundle_path)
-      unless call_simctl(["launch", @device_id, test_host_bundle_identifier, '-XCTest', 'All', dylib_logfile_path, test_bundle_path], env: env)
+      unless call_simctl(['launch', @device_id, test_host_bundle_identifier, '-XCTest', 'All', dylib_logfile_path, test_bundle_path], env: env)
         raise TestDumpError, "Launching #{test_bundle_path} in #{test_host_bundle_identifier} failed"
       end
     end
 
     def run_logic_test(env, test_host, test_bundle_path)
-      opts = @debug ? {} : { err: "/dev/null" }
-      unless call_simctl(["spawn", @device_id, test_host, '-XCTest', 'All', dylib_logfile_path, test_bundle_path], env: env, **opts)
+      opts = @debug ? {} : { err: '/dev/null' }
+      unless call_simctl(['spawn', @device_id, test_host, '-XCTest', 'All', dylib_logfile_path, test_bundle_path], env: env, **opts)
         raise TestDumpError, "Spawning #{test_bundle_path} in #{test_host} failed"
       end
     end
@@ -398,10 +433,10 @@ module XCKnife
     end
 
     def xctest_type(test_bundle)
-      if test_bundle["TestHostBundleIdentifier"].nil?
-        "LOGICTEST"
+      if test_bundle['TestHostBundleIdentifier'].nil?
+        'LOGICTEST'
       else
-        "APPTEST"
+        'APPTEST'
       end
     end
 
@@ -412,7 +447,7 @@ module XCKnife
     end
 
     def method_from_nm_line(line)
-      return unless line.strip =~ %r{^
+      return unless line.strip =~ /^
         [\da-f]+\s # address
         [tT]\s # symbol type
         (?: # method
@@ -424,9 +459,9 @@ module XCKnife
             (.+) # class name
             \.(test.+)\s->\s\(\) # method signature
         )
-      $}ox
+      $/ox
 
-      { class: $1 || $3, method: $2 || $4 }
+      { class: Regexp.last_match(1) || Regexp.last_match(3), method: Regexp.last_match(2) || Regexp.last_match(4) }
     end
   end
 end

--- a/spec/test_dumper_spec.rb
+++ b/spec/test_dumper_spec.rb
@@ -42,7 +42,7 @@ describe XCKnife::TestDumperHelper do
       expect(test_dumper_helper).to receive(:wait_test_dumper_completion).with(other_test_specification.json_stream_file)
 
       expect(test_dumper_helper.send(:list_tests, xctestrun, list_folder, extra_environment_variables)).
-        to eq [naive_test_specification, other_test_specification]
+        to eq [other_test_specification, naive_test_specification]
     end
 
     it 'skips dumping given bundles' do

--- a/spec/testdumper_acceptance_spec.rb
+++ b/spec/testdumper_acceptance_spec.rb
@@ -1,49 +1,50 @@
 require 'spec_helper'
 require 'set'
 
-EXPECTED_OUTPUT = <<eof
-{"message":"Starting Test Dumper","event":"begin-test-suite","testType":"APPTEST"}
-{"event":"begin-ocunit","bundleName":"CommonTestTarget.xctest","targetName":"CommonTestTarget"}
-{"test":"1","className":"CommonTestClass","event":"end-test","totalDuration":"0"}
-{"message":"Completed Test Dumper","event":"end-action","testType":"APPTEST"}
-{"message":"Starting Test Dumper","event":"begin-test-suite","testType":"LOGICTEST"}
-{"event":"begin-ocunit","bundleName":"iPhoneTestTarget.xctest","targetName":"iPhoneTestTarget"}
-{"test":"1","className":"iPhoneTestClassAlpha","event":"end-test","totalDuration":"0"}
-{"test":"1","className":"iPhoneTestClassBeta","event":"end-test","totalDuration":"0"}
-{"test":"1","className":"iPhoneTestClassDelta","event":"end-test","totalDuration":"0"}
-{"test":"1","className":"iPhoneTestClassGama","event":"end-test","totalDuration":"0"}
-{"test":"1","className":"iPhoneTestClassOmega","event":"end-test","totalDuration":"0"}
-{"message":"Completed Test Dumper","event":"end-action","testType":"LOGICTEST"}
-{"message":"Starting Test Dumper","event":"begin-test-suite","testType":"LOGICTEST"}
-{"event":"begin-ocunit","bundleName":"SwiftTestTarget.xctest","targetName":"SwiftTestTarget"}
-{"test":"1","className":"ObjCTestClass","event":"end-test","totalDuration":"0"}
-{"test":"1","className":"SwiftTestTarget","event":"end-test","totalDuration":"0"}
-{"message":"Completed Test Dumper","event":"end-action","testType":"LOGICTEST"}
-{"message":"Starting Test Dumper","event":"begin-test-suite","testType":"APPTEST"}
-{"event":"begin-ocunit","bundleName":"iPadTestTarget.xctest","targetName":"iPadTestTarget"}
-{"test":"1","className":"iPadTestClassFour","event":"end-test","totalDuration":"0"}
-{"test":"1","className":"iPadTestClassOne","event":"end-test","totalDuration":"0"}
-{"test":"1","className":"iPadTestClassThree","event":"end-test","totalDuration":"0"}
-{"test":"1","className":"iPadTestClassTwo","event":"end-test","totalDuration":"0"}
-{"message":"Completed Test Dumper","event":"end-action","testType":"APPTEST"}
-eof
+EXPECTED_OUTPUT = <<~eof.freeze
+   {"message":"Starting Test Dumper","event":"begin-test-suite","testType":"APPTEST"}
+   {"event":"begin-ocunit","bundleName":"CommonTestTarget.xctest","targetName":"CommonTestTarget"}
+   {"test":"1","className":"CommonTestClass","event":"end-test","totalDuration":"0"}
+   {"message":"Completed Test Dumper","event":"end-action","testType":"APPTEST"}
+   {"message":"Starting Test Dumper","event":"begin-test-suite","testType":"LOGICTEST"}
+   {"event":"begin-ocunit","bundleName":"iPhoneTestTarget.xctest","targetName":"iPhoneTestTarget"}
+   {"test":"1","className":"iPhoneTestClassAlpha","event":"end-test","totalDuration":"0"}
+   {"test":"1","className":"iPhoneTestClassBeta","event":"end-test","totalDuration":"0"}
+   {"test":"1","className":"iPhoneTestClassDelta","event":"end-test","totalDuration":"0"}
+   {"test":"1","className":"iPhoneTestClassGama","event":"end-test","totalDuration":"0"}
+   {"test":"1","className":"iPhoneTestClassOmega","event":"end-test","totalDuration":"0"}
+   {"message":"Completed Test Dumper","event":"end-action","testType":"LOGICTEST"}
+   {"message":"Starting Test Dumper","event":"begin-test-suite","testType":"LOGICTEST"}
+   {"event":"begin-ocunit","bundleName":"SwiftTestTarget.xctest","targetName":"SwiftTestTarget"}
+   {"test":"1","className":"ObjCTestClass","event":"end-test","totalDuration":"0"}
+   {"test":"1","className":"SwiftTestTarget","event":"end-test","totalDuration":"0"}
+   {"message":"Completed Test Dumper","event":"end-action","testType":"LOGICTEST"}
+   {"message":"Starting Test Dumper","event":"begin-test-suite","testType":"APPTEST"}
+   {"event":"begin-ocunit","bundleName":"iPadTestTarget.xctest","targetName":"iPadTestTarget"}
+   {"test":"1","className":"iPadTestClassFour","event":"end-test","totalDuration":"0"}
+   {"test":"1","className":"iPadTestClassOne","event":"end-test","totalDuration":"0"}
+   {"test":"1","className":"iPadTestClassThree","event":"end-test","totalDuration":"0"}
+   {"test":"1","className":"iPadTestClassTwo","event":"end-test","totalDuration":"0"}
+   {"message":"Completed Test Dumper","event":"end-action","testType":"APPTEST"}
+ eof
 
-describe "Test Dumper Acceptance", if: RUBY_PLATFORM.include?('darwin') do
+describe 'Test Dumper Acceptance', if: RUBY_PLATFORM.include?('darwin') do
   def sh(str)
     system(str)
   end
 
   def stop_all_simulators
-    sh "pkill -9 -f CoreSimulator"
-    sh "pkill -9 -f Xcode.app"
-    sh "pkill -9 xcodebuild"
-    sh "pkill -9 Simulator"
-    sh "pkill -9 launchd_sim"
+    sh 'pkill -9 -f CoreSimulator'
+    sh 'pkill -9 -f Xcode.app'
+    sh 'pkill -9 xcodebuild'
+    sh 'pkill -9 Simulator'
+    sh 'pkill -9 launchd_sim'
   end
 
   def xcknife_exemplar_path
-    target_dir = File.join(File.dirname(__FILE__), "xcknife-exemplar")
-    raise "Please initialize with `git submodule update --recursive --init`" unless File.exists?(target_dir)
+    target_dir = File.join(File.dirname(__FILE__), 'xcknife-exemplar')
+    raise 'Please initialize with `git submodule update --recursive --init`' unless File.exist?(target_dir)
+
     target_dir
   end
 
@@ -61,7 +62,7 @@ describe "Test Dumper Acceptance", if: RUBY_PLATFORM.include?('darwin') do
     `xcrun simctl create #{sim_name} #{sim_type} #{sim_runtime}`.strip
   end
 
-  let(:derived_data_path) { File.join(xcknife_exemplar_path, "derivedDataPath") }
+  let(:derived_data_path) { File.join(xcknife_exemplar_path, 'derivedDataPath') }
   let(:outpath) { "#{__FILE__}.out.tmp" }
   let(:logger) { instance_spy(Logger) }
 
@@ -80,26 +81,28 @@ describe "Test Dumper Acceptance", if: RUBY_PLATFORM.include?('darwin') do
     sh "xcrun simctl delete #{simulator_uuid}"
 
     expect(File.read('/tmp/xcknife_testdumper_dylib.log').split("\n"))
-      .to include("Starting TestDumper...")
-      .and include("Listing all test bundles")
-      .and include("test bundle loaded")
+      .to include('Starting TestDumper...')
+      .and include('Listing all test bundles')
+      .and include('test bundle loaded')
       .and include("Found a test bundle named: #{__dir__}/xcknife-exemplar/derivedDataPath/Build/Products/Debug-iphonesimulator/XCKnifeExemplar.app/PlugIns/iPadTestTarget.xctest")
-      .and include("The test target is: iPadTestTarget of type APPTEST")
-      .and include("EndingTestDumper...")
-      .and include("Exiting with status 0")
+      .and include('The test target is: iPadTestTarget of type APPTEST')
+      .and include('EndingTestDumper...')
+      .and include('Exiting with status 0')
   end
 
-
-  it "run test dumper on example project" do
+  it 'run test dumper on example project' do
     expect { XCKnife::TestDumper.new([derived_data_path, outpath, simulator_uuid], logger: logger).run }.not_to raise_error
     expect(IO.read(outpath).lines).to eq(EXPECTED_OUTPUT.lines)
   end
 
-  it "dumps tests using nm on example project" do
-    test_bundle_names = ["CommonTestTarget", "iPhoneTestTarget", "SwiftTestTarget"]
+  it 'dumps tests using nm on example project' do
+    test_bundle_names = %w[CommonTestTarget iPhoneTestTarget SwiftTestTarget]
     expect_any_instance_of(XCKnife::TestDumperHelper).to receive(:list_tests_with_nm).exactly(3).times.and_call_original
     expect_any_instance_of(XCKnife::TestDumperHelper).to receive(:list_tests_with_simctl).once.and_call_original
     expect { XCKnife::TestDumper.new([derived_data_path, outpath, simulator_uuid, '--naive-dump', test_bundle_names.join(',')], logger: logger).run }.not_to raise_error
-    expect(IO.read(outpath).lines).to eq(EXPECTED_OUTPUT.lines)
+
+    # Test dumper outputs tests enumerated by nm by threading, check for their presence rather than their exact order
+    output_lines = IO.read(outpath).lines
+    EXPECTED_OUTPUT.lines.each { |line|  expect(output_lines).to include(line) }
   end
 end


### PR DESCRIPTION
## Priority
Normal

## What Changed & Why
This PR updates naive test dumping by spawning threads and managing results on a work queue. 

```ruby
Benchmark.bm(100) do |bm|
  bm.report("Parallel") do
     XCKnife::TestDumper.new([derived_data_path, outpath, simuuid, '--naive-dump-parallel', test_bundle_names.join(',')], logger: logger).run
   end

  bm.report("No Parallel") do
    XCKnife::TestDumper.new([derived_data_path, outpath, simuuid, '--naive-dump', test_bundle_names.join(',')], logger: logger).run
  end
end
```

```ruby
#                      user    system      total         real
# Parallel:       0.018358   0.029042   0.566829 ( 20.727528)
# No Parallel:    0.019512   0.035553   0.595414 ( 22.505788)
```

It appears that there is a slight reduction with dumping tests in parallel that I presume will be more apparent on test bundles with more tests.

## Testing
`rake`