### PR TITLE
Filter out non-methods in swift naive test dumper regexp

### DIFF
--- a/lib/xcknife/test_dumper.rb
+++ b/lib/xcknife/test_dumper.rb
@@ -454,8 +454,8 @@ module XCKnife
           | # or swift instance method
             _? # only present on Xcode 10.0 and below
             (?:@objc\s)? # optional objc annotation
-            (?:[^.]+\.)? # module name
-            (.+) # class name
+            (?:[^. ]+\.)? # module name
+            ([^ ]+) # class name
             \.(test.+)\s->\s\(\) # method signature
         )
       $/ox

--- a/spec/testdumper_acceptance_spec.rb
+++ b/spec/testdumper_acceptance_spec.rb
@@ -105,6 +105,6 @@ describe 'Test Dumper Acceptance', if: RUBY_PLATFORM.include?('darwin') do
 
     # Test dumper outputs tests enumerated by nm by threading, check for their presence rather than their exact order
     output_lines = IO.read(outpath).lines
-    EXPECTED_OUTPUT.lines.each { |line| expect(output_lines).to include(line) }
+    expect(output_lines.sort).to eq(EXPECTED_OUTPUT.lines.sort)
   end
 end

--- a/spec/xcknife-exemplar/SwiftTestTarget/SwiftTestTarget.swift
+++ b/spec/xcknife-exemplar/SwiftTestTarget/SwiftTestTarget.swift
@@ -2,5 +2,9 @@ import XCTest
 
 class SwiftTestTarget: XCTestCase {
     func testExample() {
+        XCTAssertTrue(true)
+    }
+    func test_example() {
+        XCTAssertEqual(true, true)
     }
 }

--- a/spec/xcknife-exemplar/XCKnifeExemplar.xcodeproj/xcshareddata/xcschemes/XCKnifeExemplar.xcscheme
+++ b/spec/xcknife-exemplar/XCKnifeExemplar.xcodeproj/xcshareddata/xcschemes/XCKnifeExemplar.xcscheme
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "29E4C8041CFD2084003B9C7E"
+            BuildableName = "XCKnifeExemplar.app"
+            BlueprintName = "XCKnifeExemplar"
+            ReferencedContainer = "container:XCKnifeExemplar.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -69,17 +78,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "29E4C8041CFD2084003B9C7E"
-            BuildableName = "XCKnifeExemplar.app"
-            BlueprintName = "XCKnifeExemplar"
-            ReferencedContainer = "container:XCKnifeExemplar.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -101,8 +99,6 @@
             ReferencedContainer = "container:XCKnifeExemplar.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
* Commit scheme diff
  
  This is what new Xcode wants to write

* Improve parallel test dumping spec failure messages

* Filter out non-methods in swift naive test dumper regexp
  
  Otherwise, entries such as
  
  ```
  00000000000022d0 t implicit closure #1 () throws -> Swift.Bool in SwiftTestTarget.SwiftTestTarget.test_example() -> ()
  ```
  
  Would generate “class names” such as “Bool in SwiftTestTarget.SwiftTestTarget”.
  
  This can easily be guarded against, as neither swift module nor class names can ever contain a space